### PR TITLE
fix compilation @ Trisquel 9 / Ubuntu 18.04

### DIFF
--- a/bee/net/endpoint.h
+++ b/bee/net/endpoint.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <memory>


### PR DESCRIPTION
Fails in the following setup (std::byte is not recognized)

gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Trisquel GNU/Linux 9.0, Etiona

The OS release can be considered as Ubuntu 18.04 LTS (Bionic Beaver)