### PR TITLE
Don't test platform on Linux

### DIFF
--- a/test/test_platform.lua
+++ b/test/test_platform.lua
@@ -43,6 +43,8 @@ function test_plat:test_1()
     if plat == 'linux' then
         lu.assertEquals(platform.Compiler == 'gcc' or platform.Compiler == 'clang', true)
         support.linux.Compiler = platform.Compiler
+        -- There are too many platforms Linux run on
+        support[plat].Arch = platform.Arch
     end
     if plat == 'msvc' or plat == 'msbuild' then
         lu.assertEquals(platform.Arch == 'x86' or platform.Arch == 'x86_64', true)


### PR DESCRIPTION
It truly doesn't make sense to limit Linux to work on x86_64 only (this breaks even on i586), it runs on too many platforms.