### PR TITLE
Ignore inaccessible directories

### DIFF
--- a/bee/fsevent/fsevent_linux.cpp
+++ b/bee/fsevent/fsevent_linux.cpp
@@ -23,7 +23,7 @@ namespace bee::linux::fsevent {
             m_fd_path.emplace(std::make_pair(desc, path));
             m_path_fd.emplace(std::make_pair(path, desc));
         }
-        for (auto& p : fs::directory_iterator(path)) {
+        for (auto& p : fs::directory_iterator(path, fs::directory_options::skip_permission_denied)) {
             if (fs::is_directory(p)) {
                 add_dir(p);
             }
@@ -33,7 +33,7 @@ namespace bee::linux::fsevent {
         int desc = m_path_fd[path];
         inotify_rm_watch(m_inotify_fd, desc);
         del_dir(desc);
-        for (auto& p : fs::directory_iterator(path)) {
+        for (auto& p : fs::directory_iterator(path, fs::directory_options::skip_permission_denied)) {
             if (fs::is_directory(p)) {
                 del_dir(p);
             }


### PR DESCRIPTION
This is actually a fix for [lua-language-server](https://github.com/sumneko/lua-language-server) which crashes if a directory with inaccessible permissions (e.g. owner root, mode 0700) is encountered while scanning the workspace. The crash is caused by an exception which is thrown by the fs::directory_iterator. I don't think you can watch a directory which you cannot read anyway, so skipping it is probably the most sensible approach.