### PR TITLE
add support for riscv

### DIFF
--- a/bee/thread/spinlock.h
+++ b/bee/thread/spinlock.h
@@ -12,6 +12,12 @@
     namespace bee { inline void cpu_relax() { asm volatile("yield" ::: "memory"); }}
 #elif defined(__arm__)
     namespace bee { inline void cpu_relax() { asm volatile("":::"memory"); }}
+#elif defined(__riscv)
+    namespace bee { inline void cpu_relax() {
+        int dummy;
+        asm volatile ("div %0, %0, zero" : "=r" (dummy));
+        asm volatile ("" ::: "memory");
+    }}
 #else
     #error unsupport platform
 #endif


### PR DESCRIPTION
The `cpu_relax` implementation comes from https://github.com/torvalds/linux/blob/e7c124bd04631973a3cc0df19ab881b56d8a2d50/arch/riscv/include/asm/vdso/processor.h#L14