### PR TITLE
fixed build error due to missing import

### DIFF
--- a/binding/lua_time.cpp
+++ b/binding/lua_time.cpp
@@ -1,4 +1,5 @@
 #include <bee/lua/binding.h>
+#include <time.h>
 
 #if defined(_WIN32)
 #include <Windows.h>


### PR DESCRIPTION
`clock_gettime` has no reference without its header file