### PR TITLE
fix: 修复出现指向自己的软链时会导致core问题

### DIFF
--- a/bee/filewatch/filewatch_linux.cpp
+++ b/bee/filewatch/filewatch_linux.cpp
@@ -56,8 +56,6 @@ namespace bee::filewatch {
         int desc = inotify_add_watch(m_inotify_fd, path.c_str(), IN_ALL_EVENTS);
         if (desc != -1) {
             const auto &emplace_result = m_fd_path.emplace(std::make_pair(desc, path.string()));
-            // 没有插入新元素说明key已经存在,
-            // 即该path已经监听过, 忽略不继续
             if (!emplace_result.second) {
                 return;
             }
@@ -70,7 +68,8 @@ namespace bee::filewatch {
         fs::directory_iterator iter {path, fs::directory_options::skip_permission_denied, ec };
         fs::directory_iterator end {};
         for (; !ec && iter != end; iter.increment(ec)) {
-            if (fs::is_directory(m_follow_symlinks? iter->status(ec): iter->symlink_status(ec))) {
+            std::error_code file_status_ec;
+            if (fs::is_directory(m_follow_symlinks? iter->status(file_status_ec): iter->symlink_status(file_status_ec))) {
                 add(iter->path());
             }
         }


### PR DESCRIPTION
出现一个软链指向自己时，当这个软链指向的目录有效时， 在m_recursive为true时， 会进入死循环， 最后导致目录层级过多core.
当这个软链无效时， 读取status()不加ec会直接出现Too many levels of symbolic links错误
