### PR TITLE
Add mips64el and loongarch64 architecture

### DIFF
--- a/binding/lua_platform.cpp
+++ b/binding/lua_platform.cpp
@@ -140,6 +140,8 @@ namespace bee::lua_platform {
         lua_pushstring(L, "wasm32");
 #elif defined(__wasm64__)
         lua_pushstring(L, "wasm64");
+#elif defined(__mips64)
+        lua_pushstring(L, "mips64el");
 #else
         lua_pushstring(L, "unknown");
 #endif

--- a/binding/lua_platform.cpp
+++ b/binding/lua_platform.cpp
@@ -142,6 +142,8 @@ namespace bee::lua_platform {
         lua_pushstring(L, "wasm64");
 #elif defined(__mips64)
         lua_pushstring(L, "mips64el");
+#elif defined(__loongarch64)
+        lua_pushstring(L, "loongarch64");
 #else
         lua_pushstring(L, "unknown");
 #endif


### PR DESCRIPTION
# Features
Added support for the mips64el and loongarch64 architectures.

# Test
1. For mips64el
```bash
[3/5] Run test.
OS:             linux 4.19.190
Arch:           mips64el
Compiler:       GCC 8.3.0
CRT:            libstdc++ 20190406 glibc 2.28
DEBUG:          false
..............................................................................
.....................
Ran 99 tests in 0.133 seconds, 99 successes, 0 failures
OK
[4/5] Copy build/linux/bin/bootstrap luamake
luamake alias already defined in /root/.zshrc
Done.
```
2. For loongarch64
```bash
[3/5] Run test.
OS:       	linux 4.19.0
Arch:     	loongarch64
Compiler: 	GCC 8.3.0
CRT:      	libstdc++ 20190406 glibc 2.28
DEBUG:    	false
..............................................................................
.....................
Ran 99 tests in 0.065 seconds, 99 successes, 0 failures
OK
[4/5] Copy build/linux/bin/bootstrap luamake
luamake alias already defined in /root/.zshrc
Done.
```
