### PR TITLE
Ensure that memory returned by lua_newuserdatauv() is 16-byte aligned

### DIFF
--- a/3rd/lua/lobject.h
+++ b/3rd/lua/lobject.h
@@ -462,7 +462,7 @@ typedef struct Udata {
   size_t len;  /* number of bytes */
   struct Table *metatable;
   GCObject *gclist;
-  UValue uv[1];  /* user values */
+  UValue uv[1] __attribute__((__aligned__(16)));  /* user values */
 } Udata;
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lua runtime and toolset
 * Add resume/yield hook (for debugger)
 * Enable lua_assert in debug mode
 * Disable tail calls in debug mode (for debugger)
+* Force 16-byte alignment for userdata
 
 ## 3rd Party Libraries
 

--- a/bee/lua/binding.h
+++ b/bee/lua/binding.h
@@ -214,6 +214,7 @@ namespace bee::lua {
     template <typename T, typename... Args>
     T& newudata(lua_State* L, Args&&... args) {
         static_assert(udata_has_name<T>::value);
+        static_assert(_Alignof(T) <= 16);
         int nupvalue = 0;
         if constexpr (udata_has_nupvalue<T>::value) {
             nupvalue = udata<T>::nupvalue;


### PR DESCRIPTION
This fixes issue #42 . I believe it has no real downsides even on platforms where it is not required.