### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/bee/net/endpoint.cpp
+++ b/bee/net/endpoint.cpp
@@ -5,7 +5,7 @@
 #    include <arpa/inet.h>
 #    include <netdb.h>
 #    include <sys/un.h>
-#    if defined(__FreeBSD__)
+#    if defined(__FreeBSD__) || defined(__OpenBSD__)
 #        include <netinet/in.h>
 #        include <sys/socket.h>
 #    endif

--- a/bee/net/socket.cpp
+++ b/bee/net/socket.cpp
@@ -20,7 +20,7 @@
 #    include <unistd.h>
 #    if defined(__APPLE__)
 #        include <sys/ioctl.h>
-#    elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #        include <sys/socket.h>
 #    endif
 #endif


### PR DESCRIPTION
Add defined for OpenBSD to include sys/socket.h file

**Build OK** on OpenBSD current/amd64 with luamake:
```shell
$ luamake
[0/1] Run test.
OS:             openbsd 7.4.0
Arch:           x86_64
Compiler:       Clang 16.0.6
CRT:            libc++ 160006
DEBUG:          false
```