### PR TITLE
fix <bfd.h> compile error

### DIFF
--- a/bee/crash/stacktrace_linux.cpp
+++ b/bee/crash/stacktrace_linux.cpp
@@ -1,6 +1,10 @@
 #include <bee/crash/stacktrace.h>
 #include <bee/crash/strbuilder.h>
+
+#define PACKAGE "bee.lua"
+#define PACKAGE_VERSION 1
 #include <bfd.h>
+
 #include <link.h>
 
 #include <cstdio>

--- a/compile/common.lua
+++ b/compile/common.lua
@@ -28,10 +28,6 @@ lm:conf {
             "-Wl,-E",
             "-static-libgcc",
         },
-        defines = {
-            "PACKAGE=\"bee.lua\"",
-            "PACKAGE_VERSION=1",
-        }
     },
     netbsd = {
         crt = "static",

--- a/compile/common.lua
+++ b/compile/common.lua
@@ -28,6 +28,10 @@ lm:conf {
             "-Wl,-E",
             "-static-libgcc",
         },
+        defines = {
+            "PACKAGE=\"bee.lua\"",
+            "PACKAGE_VERSION=1",
+        }
     },
     netbsd = {
         crt = "static",


### PR DESCRIPTION
在linux上编译bee.lua时报错

> [10/45] Compile C++ build/obj/source_bee/stacktrace_linux.obj
FAILED: build/obj/source_bee/stacktrace_linux.obj
gcc -MMD -MT build/obj/source_bee/stacktrace_linux.obj -MF build/obj/source_bee/stacktrace_linux.obj.d -std=c++17 -fno-rtti -O2 -Wall -fvisibility=hidden -I. -I3rd/lua -DNDEBUG -fPIC -o build/obj/source_bee/stacktrace_linux.obj -c bee/crash/stacktrace_linux.cpp
In file included from bee/crash/stacktrace_linux.cpp:3:
/usr/include/bfd.h:36:2: error: #error config.h must be included before this header
   36 | #error config.h must be included before this header
      |  ^~~~~
[35/45] Compile C++ build/obj/source_bee/format.obj
ninja: build stopped: subcommand failed.

看bfd.h的源码发现需要定义PACKAGE和PACKAGE_VERSION
```
/* PR 14072: Ensure that config.h is included first.  */
#if !defined PACKAGE && !defined PACKAGE_VERSION
#error config.h must be included before this header
#endif
```

机器信息：
> OS:             linux 5.15.153
Arch:           x86_64
Compiler:       GCC 14.1.1
CRT:            libstdc++ 20240522 glibc 2.39

希望能看下是不是需要合入