### PR TITLE
atomic_sync: Use the correct struct timespec on NetBSD for futex.

### DIFF
--- a/bee/thread/atomic_sync.cpp
+++ b/bee/thread/atomic_sync.cpp
@@ -49,7 +49,10 @@ static void futex_wait(const int* ptr, int val, const FutexTimespec* timeout) {
 #    if defined(__linux__)
     ::syscall(SYS_futex, ptr, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, timeout, 0, 0);
 #    elif defined(__NetBSD__)
-    ::syscall(SYS___futex, ptr, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, timeout, 0, 0, 0);
+    struct timespec ts;
+    ts.tv_sec = timeout->tv_sec;
+    ts.tv_nsec = timeout->tv_nsec;
+    ::syscall(SYS___futex, ptr, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, &ts, 0, 0, 0);
 #    elif defined(__OpenBSD__)
     static_assert(sizeof(FutexTimespec) == sizeof(timespec));
     ::futex((uint32_t*)const_cast<int*>(ptr), FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, (const timespec*)timeout, 0);


### PR DESCRIPTION
This is a minimum fix for the NetBSD futex syscall, but perhaps it would be better to just use struct timespec on all systems and have a special case for Linux's pre-64-bit-time_t syscall.

fix https://github.com/actboy168/bee.lua/issues/49