### PR TITLE
fix: add <cstring> to bee/net/endpoint.h to fix compilation errors

### DIFF
--- a/bee/net/endpoint.h
+++ b/bee/net/endpoint.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
Compilation errors of `lua-language-server` before changes:

```
Submodule '3rd/EmmyLuaCodeStyle' (https://github.com/CppCXY/EmmyLuaCodeStyle) registered for path '3rd/EmmyLuaCodeStyle'
Submodule '3rd/bee.lua' (https://github.com/actboy168/bee.lua) registered for path '3rd/bee.lua'
Submodule '3rd/json.lua' (https://github.com/actboy168/json.lua) registered for path '3rd/json.lua'
Submodule '3rd/love-api' (https://github.com/love2d-community/love-api) registered for path '3rd/love-api'
Submodule '3rd/lovr-api' (https://github.com/bjornbytes/lovr-docs) registered for path '3rd/lovr-api'
Submodule '3rd/lpeglabel' (https://github.com/sqmedeiros/lpeglabel) registered for path '3rd/lpeglabel'
Submodule '3rd/luamake' (https://github.com/actboy168/luamake) registered for path '3rd/luamake'
Submodule 'meta/3rd/Cocos4.0' (https://github.com/LuaCATS/cocos4.0.git) registered for path 'meta/3rd/Cocos4.0'
Submodule 'meta/3rd/Defold' (https://github.com/LuaCATS/defold.git) registered for path 'meta/3rd/Defold'
Submodule 'meta/3rd/Jass' (https://github.com/LuaCATS/jass.git) registered for path 'meta/3rd/Jass'
Submodule 'meta/3rd/OpenResty' (https://github.com/LuaCATS/openresty.git) registered for path 'meta/3rd/OpenResty'
Submodule 'meta/3rd/bee' (https://github.com/LuaCATS/bee.git) registered for path 'meta/3rd/bee'
Submodule 'meta/3rd/busted' (https://github.com/LuaCATS/busted.git) registered for path 'meta/3rd/busted'
Submodule 'meta/3rd/ffi-reflect' (https://github.com/LuaCATS/ffi-reflect.git) registered for path 'meta/3rd/ffi-reflect'
Submodule 'meta/3rd/lfs' (https://github.com/LuaCATS/luafilesystem.git) registered for path 'meta/3rd/lfs'
Submodule 'meta/3rd/love2d' (https://github.com/LuaCATS/love2d.git) registered for path 'meta/3rd/love2d'
Submodule 'meta/3rd/lovr' (https://github.com/LuaCATS/lovr.git) registered for path 'meta/3rd/lovr'
Submodule 'meta/3rd/luaecs' (https://github.com/LuaCATS/luaecs.git) registered for path 'meta/3rd/luaecs'
Submodule 'meta/3rd/luassert' (https://github.com/LuaCATS/luassert.git) registered for path 'meta/3rd/luassert'
Submodule 'meta/3rd/luv' (https://github.com/LuaCATS/luv.git) registered for path 'meta/3rd/luv'
Submodule 'meta/3rd/skynet' (https://github.com/LuaCATS/skynet.git) registered for path 'meta/3rd/skynet'
Cloning into '/home/eli/tmp/lua-language-server/3rd/EmmyLuaCodeStyle'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/bee.lua'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/json.lua'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/love-api'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/lovr-api'...
error: RPC failed; curl 18 transfer closed with outstanding read data remaining
error: 15332 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
fatal: clone of 'https://github.com/bjornbytes/lovr-docs' into submodule path '/home/eli/tmp/lua-language-server/3rd/lovr-api' failed
Failed to clone '3rd/lovr-api'. Retry scheduled
Cloning into '/home/eli/tmp/lua-language-server/3rd/lpeglabel'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/luamake'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/Cocos4.0'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/Defold'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/Jass'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/OpenResty'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/bee'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/busted'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/ffi-reflect'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/lfs'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/love2d'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/lovr'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/luaecs'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/luassert'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/luv'...
Cloning into '/home/eli/tmp/lua-language-server/meta/3rd/skynet'...
Cloning into '/home/eli/tmp/lua-language-server/3rd/lovr-api'...
Submodule path '3rd/EmmyLuaCodeStyle': checked out 'e728970f81e887aa4078edaf93af895311bf667e'
Submodule path '3rd/bee.lua': checked out '8c01c7d79612d47f47f17d80304e66ae14d7b953'
Submodule path '3rd/json.lua': checked out '9ae6772870ff0480ec83fc88dc8ffa52880b3a98'
Submodule 'test/ltest' (https://github.com/actboy168/ltest) registered for path '3rd/json.lua/test/ltest'
Cloning into '/home/eli/tmp/lua-language-server/3rd/json.lua/test/ltest'...
Submodule path '3rd/json.lua/test/ltest': checked out '5d72d81cf64e78b6a057f383cc6237b59f05b90f'
Submodule path '3rd/love-api': checked out '853639288547618dece86c3a8e52348fe304eba2'
Submodule path '3rd/lovr-api': checked out 'e89c753e1c2849b7533481fcf058095f8e050b9f'
Submodule path '3rd/lpeglabel': checked out '912b0b9e8641074408ffc2259e069b188e0c717b'
Submodule path '3rd/luamake': checked out 'c086f35cfad0236f74ba380d51f211c52a2c8abc'
Submodule '3rd/bee.lua' (https://github.com/actboy168/bee.lua) registered for path '3rd/luamake/bee.lua'
Cloning into '/home/eli/tmp/lua-language-server/3rd/luamake/bee.lua'...
Submodule path '3rd/luamake/bee.lua': checked out '038aef6f41dc09dad43325e5d3cdc3e207b6d3c0'
Submodule path 'meta/3rd/Cocos4.0': checked out 'c0b2259e0d367561fd4563ae114b029b4dfe3a8f'
Submodule path 'meta/3rd/Defold': checked out '05379b40fb3084d82f7270475e42da8d521c4dae'
Submodule path 'meta/3rd/Jass': checked out '80d85cbbfd8ae2473fb39c7df4be814602f5bc4f'
Submodule path 'meta/3rd/OpenResty': checked out '3bec36f0f645bb38b3c8208990d5c36feb66ce3d'
Submodule path 'meta/3rd/bee': checked out 'c0bc5349e5fa741d7ad8d6d5c7624a54dcfd9ebe'
Submodule path 'meta/3rd/busted': checked out '5ed85d0e016a5eb5eca097aa52905eedf1b180f1'
Submodule path 'meta/3rd/ffi-reflect': checked out 'e9037efca4021a15552b281f5e91418afd370d8f'
Submodule path 'meta/3rd/lfs': checked out '9b5cfc15be744c829c66519cb11e49669ae7e39b'
Submodule path 'meta/3rd/love2d': checked out '98f7684525a6e866ffa6df449b7aef406a807dae'
Submodule path 'meta/3rd/lovr': checked out '3ba215f98e1647111b50b311d45c31338fdc615f'
Submodule path 'meta/3rd/luaecs': checked out '21192fbdccc0f140dae2f74f7c3ec7d74e2aadd0'
Submodule path 'meta/3rd/luassert': checked out 'd3528bb679302cbfdedefabb37064515ab95f7b9'
Submodule path 'meta/3rd/luv': checked out '3615eb12c94a7cfa7184b8488cf908abb5e94c9c'
Submodule path 'meta/3rd/skynet': checked out 'afa6717ac4f71e42012fa2ebf4b410d04db647ae'
Submodule path '3rd/lovr-api': checked out 'e89c753e1c2849b7533481fcf058095f8e050b9f'
~/tmp/lua-language-server/3rd/luamake ~/tmp/lua-language-server
[1/37] Compile C   build/linux/obj/source_lua/onelua.obj
[2/37] Compile C   build/linux/obj/source_lua/linit.obj
[3/37] Compile C++ build/linux/obj/source_bee/luaref.obj
[4/37] Compile C++ build/linux/obj/source_bee/lua_time.obj
[5/37] Compile C++ build/linux/obj/source_bee/lua_thread.obj
[6/37] Compile C++ build/linux/obj/source_bee/lua_subprocess.obj
[7/37] Compile C++ build/linux/obj/source_bee/lua_socket.obj
[8/37] Compile C++ build/linux/obj/source_bee/lua_serialization.obj
[9/37] Compile C++ build/linux/obj/source_bee/lua_select.obj
[10/37] Compile C++ build/linux/obj/source_bee/lua_platform.obj
[11/37] Compile C++ build/linux/obj/source_bee/lua_filewatch.obj
[12/37] Compile C++ build/linux/obj/source_bee/lua_filesystem.obj
[13/37] Compile C++ build/linux/obj/source_bee/lua_epoll.obj
[14/37] Compile C++ build/linux/obj/source_bee/lua_debugging.obj
[15/37] Compile C++ build/linux/obj/source_bee/version.obj
[16/37] Compile C++ build/linux/obj/source_bee/path_helper.obj
[17/37] Compile C++ build/linux/obj/source_bee/file_handle_posix.obj
[18/37] Compile C++ build/linux/obj/source_bee/file_handle_linux.obj
[19/37] Compile C++ build/linux/obj/source_bee/file_handle.obj
[20/37] Compile C++ build/linux/obj/source_bee/spinlock.obj
[21/37] Compile C++ build/linux/obj/source_bee/simplethread_posix.obj
[22/37] Compile C++ build/linux/obj/source_bee/setname.obj
[23/37] Compile C++ build/linux/obj/source_bee/atomic_sync.obj
[24/37] Compile C++ build/linux/obj/source_bee/subprocess_posix.obj
[25/37] Compile C++ build/linux/obj/source_bee/process_select.obj
[26/37] Compile C++ build/linux/obj/source_bee/socket.obj
[27/37] Compile C++ build/linux/obj/source_bee/endpoint.obj
[28/37] Compile C++ build/linux/obj/source_bee/bpoll_linux.obj
[29/37] Compile C++ build/linux/obj/source_bee/filewatch_linux.obj
[30/37] Compile C++ build/linux/obj/source_bee/error.obj
[31/37] Compile C++ build/linux/obj/source_bee/format.obj
ninja: job failed: gcc -MMD -MT build/linux/obj/source_bee/endpoint.obj -MF build/linux/obj/source_bee/endpoint.obj.d -std=c++17 -fno-rtti -O2 -Wall -fvisibility=hidden -Ibee.lua -DNDEBUG -fPIC -o build/linux/obj/source_bee/endpoint.obj -c bee.lua/bee/net/endpoint.cpp
bee.lua/bee/net/endpoint.cpp: In static member function 'static bool bee::net::endpoint::ctor_unix(bee::net::endpoint&, bee::zstring_view)':
bee.lua/bee/net/endpoint.cpp:135:9: error: 'memset' was not declared in this scope
  135 |         memset(su.sun_path, 0, UNIX_PATH_MAX);
      |         ^~~~~~
bee.lua/bee/net/endpoint.cpp:22:1: note: 'memset' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
   21 | #include <limits>
  +++ |+#include <cstring>
   22 | 
bee.lua/bee/net/endpoint.cpp:136:9: error: 'memcpy' was not declared in this scope
  136 |         memcpy(su.sun_path, path.data(), path.size() + 1);
      |         ^~~~~~
bee.lua/bee/net/endpoint.cpp:136:9: note: 'memcpy' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
bee.lua/bee/net/endpoint.cpp: In member function 'bool bee::net::endpoint::operator==(const bee::net::endpoint&) const':
bee.lua/bee/net/endpoint.cpp:262:44: error: 'memcmp' was not declared in this scope
  262 |         return m_size == o.m_size && (0 == memcmp(m_data, o.m_data, m_size));
      |                                            ^~~~~~
bee.lua/bee/net/endpoint.cpp:262:44: note: 'memcmp' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
In file included from bee.lua/bee/net/endpoint.cpp:1:
bee.lua/bee/net/endpoint.h: In instantiation of 'void bee::net::endpoint::assgin(const SOCKADDR&) [with SOCKADDR = sockaddr_in]':
bee.lua/bee/net/endpoint.cpp:114:22:   required from here
  114 |             ep.assgin(*(const sockaddr_in*)info->ai_addr);
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
bee.lua/bee/net/endpoint.h:50:19: error: 'memcpy' was not declared in this scope
   50 |             memcpy(m_data, &v, sizeof(v));
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
bee.lua/bee/net/endpoint.h:7:1: note: 'memcpy' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
    6 | #include <cstdint>
  +++ |+#include <cstring>
    7 | #include <string>
bee.lua/bee/net/endpoint.h: In instantiation of 'void bee::net::endpoint::assgin(const SOCKADDR&) [with SOCKADDR = sockaddr_in6]':
bee.lua/bee/net/endpoint.cpp:121:22:   required from here
  121 |             ep.assgin(*(const sockaddr_in6*)info->ai_addr);
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
bee.lua/bee/net/endpoint.h:50:19: error: 'memcpy' was not declared in this scope
   50 |             memcpy(m_data, &v, sizeof(v));
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
bee.lua/bee/net/endpoint.h:50:19: note: 'memcpy' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
bee.lua/bee/net/endpoint.h: In instantiation of 'void bee::net::endpoint::assgin(const SOCKADDR&) [with SOCKADDR = sockaddr_un]':
bee.lua/bee/net/endpoint.cpp:137:18:   required from here
  137 |         ep.assgin(su);
      |         ~~~~~~~~~^~~~
bee.lua/bee/net/endpoint.h:50:19: error: 'memcpy' was not declared in this scope
   50 |             memcpy(m_data, &v, sizeof(v));
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
bee.lua/bee/net/endpoint.h:50:19: note: 'memcpy' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
ninja: subcommand failed
~/tmp/lua-language-server
./make.sh: line 8: 3rd/luamake/luamake: No such file or directory
```