### PR TITLE
fix: Add missing cstring include for memset, memcmp, memcpy

### DIFF
--- a/bee/net/endpoint.cpp
+++ b/bee/net/endpoint.cpp
@@ -27,6 +27,7 @@ struct sockaddr_un {
 #include <bee/nonstd/charconv.h>
 
 #include <array>
+#include <cstring>
 #include <limits>
 
 namespace bee::net {


### PR DESCRIPTION
memset, memcmp and memcpy are defined in the header cstring as per the C++ standard. Some - but not all - implementations also make those functions indirectly available through other headers, but this behavior should not be relied upon.

In my specific case, building on Alpine Linux with the musl libc failed due to this.