### PR TITLE
fix test_thread:test_sleep

### DIFF
--- a/test/test_thread.lua
+++ b/test/test_thread.lua
@@ -105,5 +105,5 @@ function test_thread:test_sleep()
     local t1 = time.monotonic()
     thread.sleep(1)
     local t2 = time.monotonic()
-    lt.assertEquals(t2 - t1 <= 2, true)
+    lt.assertEquals(t2 - t1 >= 1, true)
 end


### PR DESCRIPTION
The original code is assuming that after a sleep of 1 second, the thread will be rescheduled within 1 second. So the total elapsed time is asserted to be no more than 2 seconds.

This is usually true, but I have had this test fail for me under load in a virtual machine. The only guarantee is that after the call `thread.sleep(1)` that at least 1 second has passed.